### PR TITLE
Add Super Admin Order History Page UI with Tabs and Tables

### DIFF
--- a/src/app/(super-admin)/super-admin/dashboard/category/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/category/page.tsx
@@ -1,8 +1,8 @@
 import { CategoriesTable } from "../../../../../components/pages/super-admin/category/CategoriesTable";
 
-export default async function Page() {
+export default async function CategoriesPage() {
   return (
-    <div>
+    <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
         <CategoriesTable/>
     </div>
   );

--- a/src/app/(super-admin)/super-admin/dashboard/coin-plan/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/coin-plan/page.tsx
@@ -1,8 +1,8 @@
 import CoinPlanTable from "@/src/components/pages/super-admin/coin-plan/CoinPlanTable";
 
-export default async function Page() {
+export default async function CoinPlanPage() {
   return (
-    <div>
+    <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
       <CoinPlanTable />
     </div>
   );

--- a/src/app/(super-admin)/super-admin/dashboard/episode-list/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/episode-list/page.tsx
@@ -1,8 +1,8 @@
 import EpisodeTable from "../../../../../components/pages/super-admin/episode-list/EpisodeTable";
 
-export default async function Page() {
+export default async function EpisodeListPage() {
   return (
-    <div>
+    <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
       <EpisodeTable />
     </div>
   );

--- a/src/app/(super-admin)/super-admin/dashboard/film-list/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/film-list/page.tsx
@@ -1,8 +1,8 @@
 import FilmTable from "../../../../../components/pages/super-admin/film-list/FilmTable";
 
-export default async function Page() {
+export default async function FilmListPage() {
   return (
-    <div>
+    <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
       <FilmTable />
     </div>
   );

--- a/src/app/(super-admin)/super-admin/dashboard/layout.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/layout.tsx
@@ -1,5 +1,5 @@
 import DashboardNavbar from "@/src/components/common/DashboardNavbar";
-import DashboardSidebar, { MobileSidebarTrigger } from "@/src/components/common/DashboardSidebar";
+import DashboardSidebar from "@/src/components/common/DashboardSidebar";
 import { SuperAdminSidebarItems } from "@/src/constants/DashboardSidebarItems";
 // import { hasRole } from "@/src/utils/roles";
 // import { redirect } from "next/navigation";

--- a/src/app/(super-admin)/super-admin/dashboard/order-history/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/order-history/page.tsx
@@ -1,0 +1,15 @@
+import CoinHistoryTable from "@/src/components/pages/super-admin/order-history/CoinHistoryTable"
+import OrderHistoryTabs from "@/src/components/pages/super-admin/order-history/OrderHistoryTabs"
+
+const Page = () => {
+  return (
+    <>
+        <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
+            <h3 className="text-2xl font-semibold mb-4">Order History</h3>
+            <OrderHistoryTabs/>
+        </div>
+    </>
+  )
+}
+
+export default Page

--- a/src/app/(super-admin)/super-admin/dashboard/order-history/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/order-history/page.tsx
@@ -1,4 +1,3 @@
-import CoinHistoryTable from "@/src/components/pages/super-admin/order-history/CoinHistoryTable"
 import OrderHistoryTabs from "@/src/components/pages/super-admin/order-history/OrderHistoryTabs"
 
 const VipPlanPage = () => {

--- a/src/app/(super-admin)/super-admin/dashboard/order-history/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/order-history/page.tsx
@@ -1,7 +1,7 @@
 import CoinHistoryTable from "@/src/components/pages/super-admin/order-history/CoinHistoryTable"
 import OrderHistoryTabs from "@/src/components/pages/super-admin/order-history/OrderHistoryTabs"
 
-const Page = () => {
+const VipPlanPage = () => {
   return (
     <>
         <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
@@ -12,4 +12,4 @@ const Page = () => {
   )
 }
 
-export default Page
+export default VipPlanPage

--- a/src/app/(super-admin)/super-admin/dashboard/user/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/user/page.tsx
@@ -2,7 +2,7 @@ import { UsersTable } from "../../../../../components/pages/super-admin/user/Use
 
 export default async function Page() {
   return (
-    <div>
+    <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
         <UsersTable/>
     </div>
   );

--- a/src/app/(super-admin)/super-admin/dashboard/user/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/user/page.tsx
@@ -1,6 +1,6 @@
 import { UsersTable } from "../../../../../components/pages/super-admin/user/UsersTable";
 
-export default async function Page() {
+export default async function UserTablePage() {
   return (
     <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
         <UsersTable/>

--- a/src/app/(super-admin)/super-admin/dashboard/vip-plan/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/vip-plan/page.tsx
@@ -2,7 +2,7 @@ import VipPlanTable from "@/src/components/pages/super-admin/vip-plan/VipPlanTab
 
 export default async function Page() {
   return (
-    <div>
+    <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
       <VipPlanTable/>
     </div>
   );

--- a/src/app/(super-admin)/super-admin/dashboard/vip-plan/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/vip-plan/page.tsx
@@ -1,6 +1,6 @@
 import VipPlanTable from "@/src/components/pages/super-admin/vip-plan/VipPlanTable";
 
-export default async function Page() {
+export default async function VipPlanPage() {
   return (
     <div className="bg-[#F3F4F6] rounded-2xl p-2 md:px-9 md:py-6">
       <VipPlanTable/>

--- a/src/components/common/ReusableTable.tsx
+++ b/src/components/common/ReusableTable.tsx
@@ -122,13 +122,13 @@ const TableRow = <T,>({
       {columns.map((column) => (
         <td
           key={column.key}
-          className={`px-6 py-4 whitespace-nowrap ${column.width ? column.width : ""}`}
+          className={`text-center px-6 py-4 whitespace-nowrap ${column.width ? column.width : ""}`}
         >
           {column.render ? column.render((row as any)[column.key], row) : (row as any)[column.key]}
         </td>
       ))}
       {actions && actions.length > 0 && (
-        <td className="px-6 py-4 whitespace-nowrap">
+        <td className="px-6 py-4 whitespace-nowrap flex items-center justify-center">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
@@ -180,18 +180,18 @@ const ReusableTable = <T,>({
       />
       <div className="overflow-x-auto px-4">
         <table className="w-full">
-          <thead className="rounded-t-2xl bg-[#16151A]">
+          <thead className="bg-[#16151A]">
             <tr>
-              {columns.map((column) => (
+              {columns.map((column, index) => (
                 <th
                   key={column.key}
-                  className={`px-6 py-3 text-left text-xs font-medium tracking-wider text-white uppercase ${column.width || ""}`}
+                  className={`px-6 py-3 text-center text-xs font-medium tracking-wider text-white uppercase ${column.width || ""} ${index === 0 ? "rounded-tl-lg" : ""} ${index === columns.length -1 && (!actions || actions.length === 0 ? "rounded-tr-lg" : "")}`}
                 >
                   {column.label}
                 </th>
               ))}
               {actions && actions.length > 0 && (
-                <th className="w-16 px-6 py-3 text-left text-xs font-medium tracking-wider text-white uppercase">
+                <th className="w-16 px-6 py-3 text-center text-xs font-medium tracking-wider text-white uppercase rounded-tr-lg">
                   Action
                 </th>
               )}

--- a/src/components/common/ReusableTableRow.tsx
+++ b/src/components/common/ReusableTableRow.tsx
@@ -30,7 +30,7 @@ export const ReusableTableRow = <T,>({
       {columns.map((column) => (
         <td
           key={column.key}
-          className={`px-6 py-4 whitespace-nowrap ${column.width ? column.width : ""}`}
+          className={`text-center px-6 py-4 whitespace-nowrap ${column.width ? column.width : ""}`}
         >
           {column.render ? column.render((row as any)[column.key], row) : (row as any)[column.key]}
         </td>

--- a/src/components/pages/super-admin/category/CategoriesTable.tsx
+++ b/src/components/pages/super-admin/category/CategoriesTable.tsx
@@ -134,7 +134,7 @@ const columns: TableColumn<UserData>[] = [
   {
     key: "name",
     label: "User Name",
-    width: "w-48",
+    width: "w-48 text-start",
     render: (value, row) => (
       <div className="flex items-center">
         <Avatar className="mr-3 h-8 w-8">

--- a/src/components/pages/super-admin/episode-list/EpisodeTable.tsx
+++ b/src/components/pages/super-admin/episode-list/EpisodeTable.tsx
@@ -141,7 +141,7 @@ const columns: TableColumn<EpisodeListData>[] = [
   {
     key: "videoImage",
     label: "Video Image",
-    width: "w-28",
+    width: "w-28 text-start",
     render: (value) => (
       <div className="h-12 w-12 flex-shrink-0">
         <img

--- a/src/components/pages/super-admin/film-list/FilmTable.tsx
+++ b/src/components/pages/super-admin/film-list/FilmTable.tsx
@@ -198,7 +198,7 @@ const FilmTable = () => {
     {
       key: "image",
       label: "Image",
-      width: "w-20",
+      width: "w-20 text-start",
       render: (value) => (
         <div className="h-12 w-12 flex-shrink-0">
           <img

--- a/src/components/pages/super-admin/order-history/CoinHistoryTable.tsx
+++ b/src/components/pages/super-admin/order-history/CoinHistoryTable.tsx
@@ -1,0 +1,171 @@
+"use client";
+import ReusableTable from "@/src/components/common/ReusableTable";
+import { Button } from "@/src/components/ui/button";
+import { TableColumn, TableHeaderConfig } from "@/src/types/reusableTable";
+import { useMemo, useState } from "react";
+
+interface CoinHistoryData {
+  no: string;
+  name: string;
+  totalPurchases: number;
+  amountSpent: string;
+  date: string;
+}
+
+const CoinHistoryData: CoinHistoryData[] = [
+  {
+    no: "01",
+    name: "Basic",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+  {
+    no: "02",
+    name: "Premium",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+  {
+    no: "03",
+    name: "gold",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+  {
+    no: "04",
+    name: "Basic",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+  {
+    no: "05",
+    name: "Basic",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+  {
+    no: "07",
+    name: "Basic",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+  {
+    no: "08",
+    name: "Basic",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+  {
+    no: "09",
+    name: "Basic",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+  {
+    no: "10",
+    name: "Basic",
+    totalPurchases: 150,
+    amountSpent: "$5,000",
+    date: "2025-08-01",
+  },
+];
+
+const columns: TableColumn<CoinHistoryData>[] = [
+  {
+    key: "no",
+    label: "No",
+    width: "w-16",
+  },
+  {
+    key: "name",
+    label: "Name",
+    width: "w-16",
+  },
+  {
+    key: "totalPurchases",
+    label: "Total Purchases",
+    width: "w-16",
+  },
+  {
+    key: "amountSpent",
+    label: "Amount Spent",
+    width: "w-16",
+  },
+  {
+    key: "date",
+    label: "Date",
+    width: "w-16",
+    render: (value) => <span className="">{value}</span>,
+  },
+  {
+    key: "history",
+    label: "History",
+    width: "w-16",
+    render: () => (
+      <Button variant="ghost" size="sm" className="">
+        View Details
+      </Button>
+    ),
+  },
+];
+
+const headerConfig: TableHeaderConfig = {
+  title: "Total Earnings: $12,366",
+  showSearch: true,
+  searchPlaceholder: "Search",
+  showDateFilter: true,
+};
+
+function CoinHistoryTable() {
+  const [searchValue, setSearchValue] = useState("");
+  const [showTodayOnly, setShowTodayOnly] = useState(false);
+
+  const filteredData = useMemo(() => {
+    let filtered = CoinHistoryData;
+
+    // search filter
+    if (searchValue.trim()) {
+      filtered = filtered.filter(
+        (user) =>
+          user.name.toLowerCase().includes(searchValue.toLowerCase()) ||
+          user.no.includes(searchValue)
+      );
+    }
+
+    // Apply date filter Today
+    if (showTodayOnly) {
+      const today = new Date().toLocaleDateString("en-BD");
+      filtered = filtered.filter((plan) => plan.date === today);
+    }
+
+    return filtered;
+  }, [searchValue, showTodayOnly]);
+
+  const handleDateFilterClick = () => {
+    setShowTodayOnly(!showTodayOnly);
+  };
+
+  return (
+    <div className="mt-4">
+      <ReusableTable
+        data={filteredData}
+        columns={columns}
+        headerConfig={headerConfig}
+        onRowClick={(row) => console.warn("Row clicked", row)}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        onDateFilterClick={handleDateFilterClick}
+      />
+    </div>
+  );
+}
+
+export default CoinHistoryTable;

--- a/src/components/pages/super-admin/order-history/OrderHistoryTabs.tsx
+++ b/src/components/pages/super-admin/order-history/OrderHistoryTabs.tsx
@@ -1,0 +1,40 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import CoinHistoryTable from "./CoinHistoryTable";
+import VIPHistoryTable from "./VIPHistoryTable";
+import { Separator } from "@/src/components/ui/separator";
+
+const tabs = [
+  {
+    name: "Coin Plan",
+    value: "coin-plan",
+    content: <CoinHistoryTable />,
+  },
+  {
+    name: "VIP Plan",
+    value: "vip plan",
+    content: <VIPHistoryTable />,
+  },
+];
+export default function TabsWithBadgeDemo() {
+  return (
+    <Tabs defaultValue={tabs[0].value} className="w-full relative">
+      <Separator className="absolute top-9" />
+      <TabsList className="w-fit justify-start gap-1 rounded-none border-b p-0">
+        {tabs.map((tab) => (
+          <TabsTrigger
+            key={tab.value}
+            value={tab.value}
+            className="data-[state=active]:border-b-primary h-full rounded-none border-b-2 border-transparent pb-4 pl-0 text-[#4E4E4E] data-[state=active]:bg-[#F3F4F6] data-[state=active]:text-black data-[state=active]:shadow-none"
+          >
+            <span className="text-base">{tab.name}</span>
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {tabs.map((tab) => (
+        <TabsContent key={tab.value} value={tab.value}>
+          {tab.content}
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}

--- a/src/components/pages/super-admin/order-history/VIPHistoryTable.tsx
+++ b/src/components/pages/super-admin/order-history/VIPHistoryTable.tsx
@@ -1,0 +1,231 @@
+"use client";
+import ReusableTable from "@/src/components/common/ReusableTable";
+import { Button } from "@/src/components/ui/button";
+import { TableColumn, TableHeaderConfig } from "@/src/types/reusableTable";
+import { useMemo, useState } from "react";
+
+interface VIPHistoryData {
+  no: string;
+  id: string;
+  userName: string; 
+  name: string;
+  paymentGateway: string;
+  price: string;
+  offerPrice: string;
+  validity: string;
+  validityType: string;
+  date: string;
+}
+
+const VIPHistoryData: VIPHistoryData[] = [
+  {
+    no: "01",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+  {
+    no: "02",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+  {
+    no: "03",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+  {
+    no: "04",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+  {
+    no: "05",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+  {
+    no: "07",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+  {
+    no: "08",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+  {
+    no: "09",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+  {
+    no: "10",
+    id: "VIP001",
+    userName: "John Doe",
+    name: "Premium Plan",
+    paymentGateway: "Premium Plan",
+    price: "$19.99",
+    offerPrice: "$14.99",
+    validity: "1 Month",
+    validityType: "Monthly",
+    date: "2025-08-01",
+  },
+];
+
+const columns: TableColumn<VIPHistoryData>[] = [
+  {
+    key: "no",
+    label: "No",
+    width: "w-16",
+  },
+  {
+    key: "id",
+    label: "Unique ID",
+    width: "w-16",
+  },
+  {
+    key: "userName",
+    label: "UserName",
+    width: "w-16",
+  },
+  {
+    key: "name",
+    label: "Name",
+    width: "w-16",
+  },
+  {
+    key: "paymentGateway",
+    label: "Payment Gateway",
+    width: "w-16",
+  },
+  {
+    key: "offerPrice",
+    label: "Offer Price",
+    width: "w-16",
+  },
+  {
+    key: "validity",
+    label: "Validity",
+    width: "w-16",
+  },
+  {
+    key: "validityType",
+    label: "Validity Type",
+    width: "w-16",
+  },
+  {
+    key: "date",
+    label: "Date",
+    width: "w-16",
+    render: (value) => <span className="">{value}</span>,
+  }
+];
+
+const headerConfig: TableHeaderConfig = {
+  title: "Total Earnings: $12,366",
+  showSearch: true,
+  searchPlaceholder: "Search",
+  showDateFilter: true,
+};
+
+function VIPHistoryTable() {
+  const [searchValue, setSearchValue] = useState("");
+  const [showTodayOnly, setShowTodayOnly] = useState(false);
+
+  const filteredData = useMemo(() => {
+    let filtered = VIPHistoryData;
+
+    // search filter
+    if (searchValue.trim()) {
+      filtered = filtered.filter(
+        (user) =>
+          user.name.toLowerCase().includes(searchValue.toLowerCase()) ||
+          user.no.includes(searchValue)
+      );
+    }
+
+    // Apply date filter Today
+    if (showTodayOnly) {
+      const today = new Date().toLocaleDateString("en-BD");
+      filtered = filtered.filter((plan) => plan.date === today);
+    }
+
+    return filtered;
+  }, [searchValue, showTodayOnly]);
+
+  const handleDateFilterClick = () => {
+    setShowTodayOnly(!showTodayOnly);
+  };
+
+  return (
+    <div className="mt-4">
+      <ReusableTable
+        data={filteredData}
+        columns={columns}
+        headerConfig={headerConfig}
+        onRowClick={(row) => console.warn("Row clicked", row)}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        onDateFilterClick={handleDateFilterClick}
+      />
+    </div>
+  );
+}
+
+export default VIPHistoryTable;

--- a/src/constants/DashboardSidebarItems.tsx
+++ b/src/constants/DashboardSidebarItems.tsx
@@ -39,7 +39,7 @@ export const SuperAdminSidebarItems = [
     children: [
       { title: "Coin Plan", href: "/super-admin/dashboard/coin-plan" },
       {title: "VIP Plan", href: "/super-admin/dashboard/vip-plan"},
-      { title: "Order History", href: "/packages/order-history" },
+      { title: "Order History", href: "/super-admin/dashboard/order-history" },
     ],
   },
   {

--- a/src/constants/SuperAdminItems.tsx
+++ b/src/constants/SuperAdminItems.tsx
@@ -120,7 +120,7 @@ export const columns: TableColumn<UserData>[] = [
   {
     key: "name",
     label: "User Name",
-    width: "w-48",
+    width: "w-48 text-left",
     render: (value, row) => (
       <div className="flex items-center">
         <Avatar className="mr-3 h-8 w-8">

--- a/src/types/reusableTable.ts
+++ b/src/types/reusableTable.ts
@@ -6,7 +6,8 @@ export interface TableColumn <T = any>{
     width?:string
     render?: (value:any, row:T)=>React.ReactNode
     sortable?:boolean
-
+    cellAlign?: 'left' | 'center' | 'right';
+    headerAlign?: 'left' | 'center' | 'right';
 }
 
 export interface AllFilterAction<T = any>{


### PR DESCRIPTION
**Description**
This PR introduces the UI for the Super Admin order history page. The page allows admins to view order histories for coin and VIP plans in a structured and user-friendly manner.

**Changes Made**
- Added a tabbed interface to separate coin and VIP plan order histories.
- Implemented content tables within each tab to display relevant order history data.
- Ensured the UI is responsive and follows the project's design guidelines.

https://github.com/user-attachments/assets/2597b0dc-f89d-4c80-ac87-3f68a72ba5cf